### PR TITLE
Passing all props of the component to Svg component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -92,7 +92,7 @@ export default class SvgAnimatedLinearGradient extends Component {
     render() {
 
         return (
-            <AnimatedSvg height={this.props.height} width={this.props.width}>
+            <AnimatedSvg {...this.props}>
                 <Svg.Defs>
                     <Svg.LinearGradient id="grad" x1={this.props.x1} y1={this.props.y1} x2={this.props.x2} y2={this.props.y2}>
                         <Svg.Stop


### PR DESCRIPTION
This change allows using the `viewBox` prop, for example, which can be used to scale the SVG properly. Or any other prop of `Svg` component.