### PR TITLE
Add typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "react-native-svg-animated-linear-gradient",
   "version": "0.4.0",
   "description": "Animated linear gradient for React Native Svg",
+  "types": "typings/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/virusvn/react-native-svg-animated-linear-gradient.git"

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ export default class SvgAnimatedLinearGradient extends Component {
         }
         return x
     }
-    componentDidMount(props) {
+    componentDidMount() {
         this._isMounted = true
         this.loopAnimation()
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Animated } from 'React-native'
+
+export interface GradientPropsMandatory {
+  primaryColor: string
+  secondaryColor: string
+  duration: number
+  width: number | string
+  heigh: number | string
+  x1: string,
+  y1: string,
+  x2: string,
+  y2: string,
+  useNativeDriver: bool,
+}
+export type GradientProps = Partial<GradientPropsMandatory>
+
+export default class SvgAnimatedLinearGradient extends React.Component {
+  state: {
+    initialOffsetValues: [number, number, number]
+    offsetValues: [string, string, string]
+    offsets: [string, string, string]
+    frequence: number
+  }
+
+  _isMounted: boolean
+  _animate: Animated.Value
+
+  static propTypes: Record<keyof GradientPropsMandatory, any>
+  static defaultProps: GradientPropsMandatory
+
+  constructor(props: GradientProps)
+
+  offsetValueBound(x: number | string): number | string
+  componentDidMount(props: GradientProps): void
+  componentWillUnmount(): void
+  loopAnimation(): void
+  render(): JSX.Element
+}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -26,7 +26,9 @@ export default class SvgAnimatedLinearGradient extends React.Component {
   _isMounted: boolean
   _animate: Animated.Value
 
-  static propTypes: Record<keyof GradientPropsMandatory, any>
+  // propTypes can't be documented without interfering with existing prop typings
+  // This is not a big issue, since everyone using TS won't need to use propTypes, and the ones using JS won't be affected at all:
+  // The propTypes static property won't be shown, but the IDE will still read prop types correctly
   static defaultProps: GradientPropsMandatory
 
   constructor(props: GradientProps)

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6,7 +6,7 @@ export interface GradientPropsMandatory {
   secondaryColor: string
   duration: number
   width: number | string
-  heigh: number | string
+  height: number | string
   x1: string,
   y1: string,
   x2: string,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Animated } from 'React-native'
+import { Animated } from 'react-native'
 
 export interface GradientPropsMandatory {
   primaryColor: string

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -32,7 +32,7 @@ export default class SvgAnimatedLinearGradient extends React.Component {
   constructor(props: GradientProps)
 
   offsetValueBound(x: number | string): number | string
-  componentDidMount(props: GradientProps): void
+  componentDidMount(): void
   componentWillUnmount(): void
   loopAnimation(): void
   render(): JSX.Element


### PR DESCRIPTION
This PR adds typings to the package:
- Users using JavaScript will get type documentation from their IDE (if they support it), and no code has to be changed.
- Users using TypeScript will also get type documentation, but they can also use them for static type checking.

These typings will need to be updated along with the package: publishing a new version without updating the typings may result in some important issues for the TypeScript users.